### PR TITLE
Enable Swagger UI by default in Quarkus implementation

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -8,4 +8,4 @@ quarkus.http.cors=true
 quarkus.http.cors.origins=http://localhost
 quarkus.http.cors.headers=accept, origin, authorization, content-type, x-requested-with
 quarkus.http.cors.methods=GET,POST,OPTIONS
-
+quarkus.swagger-ui.always-include=true


### PR DESCRIPTION
Hi @nicolasduminil 

I am testing this application as per instructions included in the future Enable Architect article. I was only able to access the Swagger UI for the Quarkus implementation after adding this option. Please let me know if you want to include it by default in your repository.